### PR TITLE
Correct domain name for OTI server (in production)

### DIFF
--- a/production/api.config
+++ b/production/api.config
@@ -21,7 +21,7 @@ OPENTREE_API_HOST=api.opentreeoflife.org
 
 OPENTREE_API_BASE_URL=http://${OPENTREE_API_HOST}/phylesystem/v1
 # Extraneous http:// is needed for now, but should get phased out
-OTI_BASE_URL=http://${OPENTREE_HOST}/oti/v1
+OTI_BASE_URL=http://${OPENTREE_API_HOST}/oti/v1
 
 OPEN_TREE_API_LOGGING_LEVEL=debug
 OPEN_TREE_API_LOGGING_FILEPATH=/home/opentree/log/api.log


### PR DESCRIPTION
This has been functional, but it looks like the intent was to use
api.opentreeoflife.org for all APIs. Previously this gave us the 
OTI base URL http://ot20.opentreeoflife.org/oti/v1  
