### PR TITLE
updated current config files to correctly redirect after authentication

### DIFF
--- a/asterales/ot17.config
+++ b/asterales/ot17.config
@@ -23,10 +23,10 @@ OTI_BASE_URL=//${OPENTREE_API_HOST}/oti/v1
 OPENTREE_GH_IDENTITY=~/.ssh/opentree/opentreeapi-gh.pem
 
 # TREEVIEW_GITHUB_CLIENT_ID=dff0cf4bb02360426224
-# TREEVIEW_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/opentree/user/login
+# TREEVIEW_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/opentree
 
 # CURATION_GITHUB_CLIENT_ID=d02feed213fd327e3005
-# CURATION_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
+# CURATION_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator
 
 export PEYOTL_LOGGING_LEVEL=debug
 export PEYOTL_LOG_FILE_PATH=/home/opentree/log/peyotl.log
@@ -43,7 +43,7 @@ OPENTREE_DOCSTORE=asterales-phylesystem
 
 # phylesystem API
 # GITHUB_CLIENT_ID=9a81785e2af910035667
-# GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
+# GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator
 # NOTE that GITHUB_CLIENT_SECRET is kept in a separate file, outside of the repo
 
 # /home/opentree/ is problematic.

--- a/development/devapi.config
+++ b/development/devapi.config
@@ -22,7 +22,7 @@ COLLECTIONS_API_BASE_URL=//devapi.opentreeoflife.org/v2
 FAVORITES_API_BASE_URL=//devapi.opentreeoflife.org/v2
 
 GITHUB_CLIENT_ID=9a81785e2af910035667
-GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
+GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator
 # NOTE that GITHUB_CLIENT_SECRET is kept in a separate file, outside of the repo
  
 

--- a/development/devtree.config
+++ b/development/devtree.config
@@ -15,13 +15,13 @@ OTI_BASE_URL=//${OPENTREE_NEO4J_HOST}/oti/v1
 OPENTREE_PUBLIC_DOMAIN=devtree.opentreeoflife.org
 
 TREEVIEW_GITHUB_CLIENT_ID=8cdc1fa7f5a3a416f958
-TREEVIEW_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/opentree/user/login
+TREEVIEW_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/opentree
 # N.B. The GITHUB_CLIENT_SECRET is stored separately, in file
 # ~/.ssh/opentree/treeview-GITHUB_CLIENT_SECRET-devtree.opentreeoflife.org
 
 # See https://github.com/organizations/OpenTreeOfLife/settings/applications
 CURATION_GITHUB_CLIENT_ID=d731965529a15ef9d529
-CURATION_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
+CURATION_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator
 # N.B. The GITHUB_CLIENT_SECRET is stored separately, in file
 # ~/.ssh/opentree/curator-GITHUB_CLIENT_SECRET-devtree.opentreeoflife.org
 

--- a/generate-config.py
+++ b/generate-config.py
@@ -81,11 +81,11 @@ OTI_BASE_URL=http://{otihost}/oti  # {otihost_tag}
 OPENTREE_API_BASE_URL=http://{apihost}/api/v1  # {apihost_tag}
 
 CURATION_GITHUB_CLIENT_ID=9a81785e2af910035667
-CURATION_GITHUB_REDIRECT_URI=http://${{OPENTREE_PUBLIC_DOMAIN}}/curator/user/login
+CURATION_GITHUB_REDIRECT_URI=http://${{OPENTREE_PUBLIC_DOMAIN}}/curator
 # NOTE that GITHUB_CLIENT_SECRET is kept in a separate file, outside of the repo
 
 TREEVIEW_GITHUB_CLIENT_ID=32cb7a650c449237398d
-TREEVIEW_GITHUB_REDIRECT_URI=http://${{OPENTREE_PUBLIC_DOMAIN}}/opentree/user/login
+TREEVIEW_GITHUB_REDIRECT_URI=http://${{OPENTREE_PUBLIC_DOMAIN}}/opentree
 # NOTE that GITHUB_CLIENT_SECRET is kept in a separate file, outside of the repo
  
 

--- a/production/tree.config
+++ b/production/tree.config
@@ -21,12 +21,12 @@ OPENTREE_PUBLIC_DOMAIN=tree.opentreeoflife.org
 # ASSUMES local testing, with modified local HOSTS file
 
 TREEVIEW_GITHUB_CLIENT_ID=dff0cf4bb02360426224
-TREEVIEW_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/opentree/user/login
+TREEVIEW_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/opentree
 # N.b. the GITHUB_CLIENT_SECRET is stored separately, in file
 # ~/.ssh/opentree/treeview-GITHUB_CLIENT_SECRET-tree.opentreeoflife.org
 
 CURATION_GITHUB_CLIENT_ID=d02feed213fd327e3005
-CURATION_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
+CURATION_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator
 # N.b. the GITHUB_CLIENT_SECRET is stored separately, in file
 # ~/.ssh/opentree/curator-GITHUB_CLIENT_SECRET-tree.opentreeoflife.org
 


### PR DESCRIPTION
This fixes [issue 685 on the opentree repo](https://github.com/OpenTreeOfLife/opentree/issues/685). We were redirecting to /user/login, which then redirected to github. 