### PR TITLE
Updating production API base URLs to match devapi

### DIFF
--- a/production/api.config
+++ b/production/api.config
@@ -22,11 +22,11 @@ FAVORITES_REPO=favorites-0  # currently unused (and no such repo)!
 OPENTREE_API_HOST=api.opentreeoflife.org
 
 # N.B. we now require HTTPS for all APIs, so scheme-relative URLs no longer make sense here
-OPENTREE_API_BASE_URL=https://${OPENTREE_API_HOST}/phylesystem/v1
+OPENTREE_API_BASE_URL=https://${OPENTREE_API_HOST}
 # OPENTREE_API_BASE_URL is needed to add the (re)indexing webhook!
-COLLECTIONS_API_BASE_URL=https://${OPENTREE_API_HOST}/v2
-FAVORITES_API_BASE_URL=https://${OPENTREE_API_HOST}/v2
-OTI_BASE_URL=https://${OPENTREE_API_HOST}/oti/v1
+COLLECTIONS_API_BASE_URL=https://${OPENTREE_API_HOST}
+FAVORITES_API_BASE_URL=https://${OPENTREE_API_HOST}
+OTI_BASE_URL=https://${OPENTREE_API_HOST}
 
 OPEN_TREE_API_LOGGING_LEVEL=debug
 OPEN_TREE_API_LOGGING_FILEPATH=/home/opentree/log/api.log


### PR DESCRIPTION
**NOTE:** This should be merged only after [the related **phylesystem-api** pull request](https://github.com/OpenTreeOfLife/phylesystem-api/pull/177) that knows how to use these simplified base URLs.